### PR TITLE
Update cfd2lcs.f90

### DIFF
--- a/src/cfd2lcs.f90
+++ b/src/cfd2lcs.f90
@@ -191,7 +191,7 @@ subroutine cfd2lcs_update(n,ux,uy,uz,time)
                               !-----
                               call compute_ftle(lcs)
 
-                              if(VELOCITY_INVARIANTS) then
+                              if(VELOCITY_INVARIANTS .AND. lcs%diagnostic==FTLE_BKWD) then
                                  call compute_invariants(lcs)
                               endif
 


### PR DESCRIPTION
No need to write the invariants with FTLE_FWD. Don't know why but it actually gives NaNs for H.